### PR TITLE
Add Documentation link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,11 @@ This is described in the `API Reference <API usage_>`_.
 It is strongly recommended that you read the Concepts_ that *Parasect* employs, if you plan to make full use of it.
 
 
+Documentation
+------------
+Find the documentation for Parasect here:https://parasect.readthedocs.io/en/latest/
+
+
 Contributing
 ------------
 


### PR DESCRIPTION
## About
I think this would be helpful, as the only documentation link I was able to find was through discuss forum post (https://discuss.px4.io/t/presenting-parasect/28906), so probably a lot of users would have struggled to find the link :thinking: 